### PR TITLE
start postgres as a child of process

### DIFF
--- a/embedded_postgres.go
+++ b/embedded_postgres.go
@@ -1,6 +1,7 @@
 package embeddedpostgres
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -9,7 +10,9 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
+	"time"
 )
 
 // EmbeddedPostgres maintains all configuration and runtime functions for maintaining the lifecycle of one Postgres process.
@@ -190,18 +193,80 @@ func (ep *EmbeddedPostgres) Stop() error {
 }
 
 func startPostgres(ep *EmbeddedPostgres) error {
-	postgresBinary := filepath.Join(ep.config.binariesPath, "bin/pg_ctl")
-	postgresProcess := exec.Command(postgresBinary, "start", "-w",
+	// We don't use pg_ctl since that starts postgres in the background. We want
+	// postgres to die if this process dies.
+
+	postgresBinary := filepath.Join(ep.config.binariesPath, "bin/postgres")
+	postgresProcess := exec.Command(postgresBinary,
 		"-D", ep.config.dataPath,
-		"-o", fmt.Sprintf(`"-p %d"`, ep.config.port))
+		"-p", strconv.Itoa(int(ep.config.port)))
 	postgresProcess.Stdout = ep.syncedLogger.file
 	postgresProcess.Stderr = ep.syncedLogger.file
 
-	if err := postgresProcess.Run(); err != nil {
-		return fmt.Errorf("could not start postgres using %s", postgresProcess.String())
+	// We open stdin so that when this process dies postgres will get a signal.
+	stdin, err := postgresProcess.StdinPipe()
+	if err != nil {
+		return err
 	}
 
-	return nil
+	if err := postgresProcess.Start(); err != nil {
+		return fmt.Errorf("could not start postgres using %s: %w", postgresProcess.String(), err)
+	}
+
+	waitErrC := make(chan error, 1)
+	go func() {
+		defer stdin.Close()
+		err := postgresProcess.Wait()
+		waitErrC <- err
+		if err != nil {
+			_, _ = fmt.Fprintf(ep.syncedLogger.file, "%v embedded-postgres process exited with non-zero exit code: %v\n", time.Now(), err)
+		}
+	}()
+
+	// Wait for pg_ctl to report happy news
+	defaultWait := 60 * time.Second // mirrors pg_ctl's DEFAULT_WAIT
+	deadline := time.Now().Add(defaultWait)
+	for time.Now().Before(deadline) {
+		if isReadyPostgres(ep) {
+			// Success
+			return nil
+		}
+
+		select {
+		case err := <-waitErrC:
+			return fmt.Errorf("could not start postgres using %s: %w", postgresProcess.String(), err)
+		case <-time.After(time.Second / 10): // mirrors pg_ctl's WAITS_PER_SEC
+			// try again
+		}
+	}
+
+	// Failed to start, best-effort kill process and return an error
+	_ = stdin.Close()
+	_ = postgresProcess.Process.Kill()
+	return fmt.Errorf("postgres failed to start after %v using %s", defaultWait, postgresProcess.String())
+}
+
+func isReadyPostgres(ep *EmbeddedPostgres) bool {
+	pgCtl := filepath.Join(ep.config.binariesPath, "bin/pg_ctl")
+	if exec.Command(pgCtl, "-D", ep.config.dataPath, "status").Run() != nil {
+		return false
+	}
+
+	// pg_ctl status returning success isn't enough, it just checks if the
+	// postmaster PID is running. To be equivalent to pg_ctl start we also need
+	// to check the status of the postmaster is ready. Without this check
+	// queries will fail at first.
+	//
+	// The format of this PID file has been stable since Postgres 10.
+	// https://sourcegraph.com/github.com/postgres/postgres@REL_15_2/-/blob/src/include/utils/pidfile.h?L44
+	linePMStatus := 8
+	pmStatusReady := "ready   "
+	b, err := os.ReadFile(filepath.Join(ep.config.dataPath, "postmaster.pid"))
+	if err != nil {
+		return false
+	}
+	lines := bytes.Split(b, []byte("\n")) // pg_ctl readline only considers \n for newline (never \r\n)
+	return len(lines) >= linePMStatus && bytes.Equal(lines[linePMStatus-1], []byte(pmStatusReady))
 }
 
 func stopPostgres(ep *EmbeddedPostgres) error {

--- a/embedded_postgres_test.go
+++ b/embedded_postgres_test.go
@@ -232,7 +232,7 @@ func Test_ErrorWhenCannotStartPostgresProcess(t *testing.T) {
 
 	err = database.Start()
 
-	assert.EqualError(t, err, fmt.Sprintf(`could not start postgres using %s/bin/pg_ctl start -w -D %s/data -o "-p 5432"`, extractPath, extractPath))
+	assert.Contains(t, err.Error(), fmt.Sprintf(`could not start postgres using %s/bin/postgres -D %s/data -p 5432`, extractPath, extractPath))
 }
 
 func Test_CustomConfig(t *testing.T) {


### PR DESCRIPTION
We currently use pg_ctl which starts postgres in the background. This means if we shutdown too fast the process is left lieing around. By directly starting the postgres binary it should get cleaned up.

To correctly support this logic we had to implement a part of what pg_ctl start does (parsing of the postmaster PID file).n

Test Plan: go test

Fixes https://github.com/sourcegraph/sourcegraph/issues/46303
