### PR TITLE
fix: always put to a temp location for download and extract

### DIFF
--- a/embedded_postgres.go
+++ b/embedded_postgres.go
@@ -106,7 +106,14 @@ func (ep *EmbeddedPostgres) Start() error {
 			}
 		}
 
-		if err := decompressTarXz(defaultTarReader, cacheLocation, ep.config.binariesPath); err != nil {
+		tempBinariesPath := ep.config.binariesPath + ".temp"
+		// Discard whatever we had previously
+		os.RemoveAll(tempBinariesPath)
+		if err := decompressTarXz(defaultTarReader, cacheLocation, tempBinariesPath); err != nil {
+			return err
+		}
+
+		if err := os.Rename(tempBinariesPath, ep.config.binariesPath); err != nil {
 			return err
 		}
 	}

--- a/embedded_postgres.go
+++ b/embedded_postgres.go
@@ -13,6 +13,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/fergusstrange/embedded-postgres/internal/fileutil"
 )
 
 // EmbeddedPostgres maintains all configuration and runtime functions for maintaining the lifecycle of one Postgres process.
@@ -107,13 +109,14 @@ func (ep *EmbeddedPostgres) Start() error {
 		}
 
 		tempBinariesPath := ep.config.binariesPath + ".temp"
-		// Discard whatever we had previously
+		// Discard whatever we had previously and always clean up afterwards
 		os.RemoveAll(tempBinariesPath)
+		defer os.RemoveAll(tempBinariesPath)
 		if err := decompressTarXz(defaultTarReader, cacheLocation, tempBinariesPath); err != nil {
 			return err
 		}
 
-		if err := os.Rename(tempBinariesPath, ep.config.binariesPath); err != nil {
+		if err := fileutil.RenameAndSync(tempBinariesPath, ep.config.binariesPath); err != nil {
 			return err
 		}
 	}

--- a/internal/fileutil/fileutil.go
+++ b/internal/fileutil/fileutil.go
@@ -1,0 +1,36 @@
+package fileutil
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// RenameAndSync will do an os.Rename followed by fsync to ensure the rename
+// is recorded
+func RenameAndSync(oldpath, newpath string) error {
+	err := os.Rename(oldpath, newpath)
+	if err != nil {
+		return err
+	}
+
+	oldparent, newparent := filepath.Dir(oldpath), filepath.Dir(newpath)
+	err = fsync(newparent)
+	if oldparent != newparent {
+		if err1 := fsync(oldparent); err == nil {
+			err = err1
+		}
+	}
+	return err
+}
+
+func fsync(path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	err = f.Sync()
+	if err1 := f.Close(); err == nil {
+		err = err1
+	}
+	return err
+}

--- a/remote_fetch.go
+++ b/remote_fetch.go
@@ -93,16 +93,16 @@ func decompressResponse(bodyBytes []byte, contentLength int64, cacheLocator Cach
 			}
 
 			cacheLocation, _ := cacheLocator()
-
-			if err := os.MkdirAll(filepath.Dir(cacheLocation), 0755); err != nil {
+			tempCacheLocation := cacheLocation + ".temp"
+			if err := os.MkdirAll(filepath.Dir(tempCacheLocation), 0755); err != nil {
 				return errorExtractingPostgres(err)
 			}
 
-			if err := ioutil.WriteFile(cacheLocation, archiveBytes, file.FileHeader.Mode()); err != nil {
+			if err := os.WriteFile(tempCacheLocation, archiveBytes, file.FileHeader.Mode()); err != nil {
 				return errorExtractingPostgres(err)
 			}
 
-			return nil
+			return os.Rename(tempCacheLocation, cacheLocation)
 		}
 	}
 


### PR DESCRIPTION
If the process gets killed halfway through download or extraction, we will get incomplete archives or binaries.

This PR changes the process first to a temporary location, and only moves to the target location once the download and extraction processes are finished.

## Test plan

```
$ rm -rf ~/.embedded-postgres-go
$ rm -rf ~/Library/Application\ Support/sourcegraph-sp/postgresql/bin
$ ./sourcegraph
```

---

Part of https://github.com/sourcegraph/sourcegraph/issues/48893