### PR TITLE
Rename directories on Windows does not need syscall.Fsync() on rename.

### DIFF
--- a/internal/fileutil/fileutil.go
+++ b/internal/fileutil/fileutil.go
@@ -1,3 +1,6 @@
+//go:build !windows
+// +build !windows
+
 package fileutil
 
 import (

--- a/internal/fileutil/fileutil_windows.go
+++ b/internal/fileutil/fileutil_windows.go
@@ -1,0 +1,14 @@
+//go:build windows
+// +build windows
+
+package fileutil
+
+import (
+	"os"
+)
+
+// RenameAndSync will do an os.Rename followed by fsync to ensure the rename
+// is recorded
+func RenameAndSync(oldpath, newpath string) error {
+	return os.Rename(oldpath, newpath)
+}


### PR DESCRIPTION
On Windows the `os.Rename` does not require a subsequent call to `syscall.Fsync()`. This change avoid `ERROR_ACCESS_DENIED` as the folder is already opened by the process that extracted the installation.